### PR TITLE
Fixing build issue with include path not including path to driver

### DIFF
--- a/Src/ILI9341_GFX.c
+++ b/Src/ILI9341_GFX.c
@@ -48,7 +48,7 @@
 #include "ILI9341_GFX.h"
 #include <string.h>
 #include "5x5_font.h"
-#include "spi.h"
+//#include "spi.h"
 
 /*Draw hollow circle at X,Y location with specified radius and colour. X and Y represent circles center */
 void ILI9341_Draw_Hollow_Circle(uint16_t X, uint16_t Y, uint16_t Radius, uint16_t Colour) {

--- a/Src/ILI9341_STM32_Driver.c
+++ b/Src/ILI9341_STM32_Driver.c
@@ -443,8 +443,11 @@ if((Y+Height-1)>=LCD_HEIGHT)
 	{
 		Height=LCD_HEIGHT-Y;
 	}
-ILI9341_Set_Address(X, Y, X+Width-1, Y+Height-1);
-ILI9341_Draw_Colour_Burst(Colour, Height*Width);
+if ((Height > 0) && (Width > 0))
+	{
+		ILI9341_Set_Address(X, Y, X+Width-1, Y+Height-1);
+		ILI9341_Draw_Colour_Burst(Colour, Height*Width);
+	}
 }
 
 //DRAW LINE FROM X,Y LOCATION to X+Width,Y LOCATION

--- a/Src/ILI9341_STM32_Driver.c
+++ b/Src/ILI9341_STM32_Driver.c
@@ -455,8 +455,11 @@ if((X+Width-1)>=LCD_WIDTH)
 	{
 		Width=LCD_WIDTH-X;
 	}
-ILI9341_Set_Address(X, Y, X+Width-1, Y);
-ILI9341_Draw_Colour_Burst(Colour, Width);
+if (Width > 0)
+	{
+		ILI9341_Set_Address(X, Y, X+Width-1, Y);
+		ILI9341_Draw_Colour_Burst(Colour, Width);
+	}
 }
 
 //DRAW LINE FROM X,Y LOCATION to X,Y+Height LOCATION
@@ -467,7 +470,10 @@ if((Y+Height-1)>=LCD_HEIGHT)
 	{
 		Height=LCD_HEIGHT-Y;
 	}
-ILI9341_Set_Address(X, Y, X, Y+Height-1);
-ILI9341_Draw_Colour_Burst(Colour, Height);
+if (Height > 0)
+	{
+		ILI9341_Set_Address(X, Y, X, Y+Height-1);
+		ILI9341_Draw_Colour_Burst(Colour, Height);
+	}
 }
 

--- a/stm32l476-ili9341-example/.cproject
+++ b/stm32l476-ili9341-example/.cproject
@@ -97,6 +97,8 @@
                                     									
                                     <listOptionValue builtIn="false" value="Core/Inc"/>
                                     								
+									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/../Src&quot;"/>
+                                    								
                                 </option>
                                 								
                                 <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.752801627" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>


### PR DESCRIPTION
Project file did not include path to "Src" directory, where the driver code lives.  As a result, the project would not build.  This pull request fixes this issue.